### PR TITLE
Use LJ_NO_UNWIND macro to control generation of .Lframe1…

### DIFF
--- a/src/vm_loongarch64.dasc
+++ b/src/vm_loongarch64.dasc
@@ -4443,6 +4443,7 @@ static void emit_asm_debug(BuildCtx *ctx)
 	"\t.align 3\n"
 	".LEFDE1:\n\n", (int)ctx->codesz - fcofs);
 #endif
+#if !LJ_NO_UNWIND
     fprintf(ctx->fp, "\t.section .eh_frame,\"a\",@progbits\n");
     fprintf(ctx->fp,
 	".Lframe1:\n"
@@ -4507,6 +4508,7 @@ static void emit_asm_debug(BuildCtx *ctx)
 	"\t.byte 0x96\n\t.uleb128 2*6\n"	/* offset fp */
 	"\t.align 2\n"
 	".LEFDE3:\n\n", (int)ctx->codesz - fcofs);
+#endif
 #endif
 #if !LJ_NO_UNWIND
     /* NYI */


### PR DESCRIPTION
…/2 and .LSFDE1/2/3